### PR TITLE
Add Atom feed and SEO metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
-#ashinogames.github.io
+# Ashino Games Microsite
+
+Static landing page for Ashino Games hosted on GitHub Pages.
+
+## Feeds
+
+- [Sitemap](https://ashinogames.com/sitemap.xml)
+- [Atom feed](https://ashinogames.com/atom.xml)

--- a/atom.xml
+++ b/atom.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Ashino Games Updates</title>
+  <link href="https://ashinogames.com/atom.xml" rel="self" />
+  <link href="https://ashinogames.com/" />
+  <updated>2025-08-19T08:41:17Z</updated>
+  <id>https://ashinogames.com/</id>
+  <author>
+    <name>Ashino Games</name>
+  </author>
+  <entry>
+    <title>Welcome to Ashino Games</title>
+    <link href="https://ashinogames.com/" />
+    <id>https://ashinogames.com/</id>
+    <updated>2025-08-19T08:41:17Z</updated>
+    <summary>Indie studio building small, polished games.</summary>
+  </entry>
+</feed>

--- a/index.html
+++ b/index.html
@@ -14,6 +14,9 @@
   <meta property="og:image:alt" content="Ashino Games logo and wordmark" />
   <meta name="twitter:creator" content="@AshinoGames" />
   <link rel="canonical" href="https://ashinogames.com/">
+  <link rel="alternate" type="application/atom+xml" title="Ashino Games Feed" href="/atom.xml">
+  <link rel="sitemap" type="application/xml" title="Sitemap" href="/sitemap.xml">
+  <meta name="keywords" content="Ashino Games, indie games, game studio, polished games">
   <meta name="robots" content="index,follow">
   <meta name="google-site-verification" content="Xgg1xBYLjLJrFjEoflo45iw2JxAPZa2865kdiax9770" />
 

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,4 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url><loc>https://ashinogames.com/</loc></url>
+  <url>
+    <loc>https://ashinogames.com/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://ashinogames.com/atom.xml</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
+  </url>
 </urlset>


### PR DESCRIPTION
## Summary
- add Atom feed and expose it via `<link rel="alternate">`
- expand sitemap with priority and feed entry
- document feeds and keywords for better SEO